### PR TITLE
add gog-backup to list of alternatives

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -95,6 +95,7 @@ These are the other GOG downloader implementations I know of:
 Written in Perl.
 * [GoGDownloader.sh](http://www.gog.com/en/forum/general/a_linux_downloader/page1)
 * [GOGDownloader (C++)](http://www.gog.com/en/forum/general/simple_gogdownloader_written_in_c)
+* [gog-backup](https://github.com/evanpowers/gog-backup) Written in Python.
 
 # Contact
 


### PR DESCRIPTION
Adds my own unofficial downloader to your list.

I've mentioned gogdl on my [comparison](https://github.com/evanpowers/gog-backup/wiki/Comparison) page; feel free to edit it if I missed one of its features. Also, thank you for writing gogdl--it's code was easy to understand and saved me some effort figuring out how to interact with GOG.com.
